### PR TITLE
Updated dependencies and example to use AngularDart 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.2.0
+
+- AngularDart 6.0.0 dependency update
+
 ### 0.1.4
 
 - Upgraded firebase versions to 7.3.0, firebaseui to 4.6.1

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,11 +1,11 @@
 name: firebase_dart_ui.example
 description: Firebase UI wrapper Example
-version: 0.0.14
+version: 0.0.20
 environment:
   sdk: '>2.0.0 <3.0.0'
 
 dependencies:
-  angular:  ^5.0.0
+  angular:  ^6.0.0
   firebase: ^7.3.0
   firebase_dart_ui:
     path: ../../firebase_dart_ui
@@ -13,4 +13,4 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.9.0
-  build_web_compilers: ^2.10.0
+  build_web_compilers: ^2.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_dart_ui
 description: An Angular Dart wrapper for Firebase UI. Demo app at https://dart-ui-demo.firebaseapp.com/
-version: 0.1.4
+version: 0.2.0
 homepage: https://github.com/wstrange/firebase_dart_ui
 author: Warren Strange <warren.strange@gmail.com>
 
@@ -8,10 +8,10 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  angular:  ^5.0.0
+  angular:  ^6.0.0
   firebase: ^7.3.0
   js: ^0.6.1+1
 
 dev_dependencies:
   build_runner: ^1.9.0
-  build_web_compilers: ^2.10.0
+  build_web_compilers: ^2.12.0


### PR DESCRIPTION
I've proposed this PR to update the library and example project dependencies to AngularDart 6.0.0. The minor version number for the library's been upped to 0.2.0 as nothing's changing regarding the public API if that sounds right?

Thanks,